### PR TITLE
useContextをRecoilに置き換え！

### DIFF
--- a/components/ui/P/P.tsx
+++ b/components/ui/P/P.tsx
@@ -1,8 +1,9 @@
-import React, { useContext } from "react";
-import { TextSizeContext, textSizeContext } from "./textSize";
+import React from "react";
+import { useRecoilValue } from "recoil";
+import { TextSize, textSizeState } from "./textSize";
 
 // 拡大率
-const expansionRate: { [key in TextSizeContext["textSize"]]: number } = {
+const expansionRate: { [key in TextSize]: number } = {
   small: 0.7,
   base: 1.0,
   large: 1.5,
@@ -16,7 +17,7 @@ type Props = React.DetailedHTMLProps<
 > & { fontSize: number };
 
 const P: React.VFC<Props> = (props) => {
-  const textSize = useContext(textSizeContext).textSize;
+  const textSize = useRecoilValue(textSizeState);
 
   // スプレッド構文が多用されてるけど、pタグにfontSizeっていうプロパティーをつけないために、fontSizeをundefinedで上書きしてるだけ
   return (

--- a/components/ui/P/textSize.tsx
+++ b/components/ui/P/textSize.tsx
@@ -1,11 +1,8 @@
-import { createContext } from "react";
+import { atom } from "recoil";
 
 // 文字サイズ（大中小）を共有するcontext
-export type TextSizeContext = {
-  textSize: "base" | "large" | "small";
-  setTextSize: React.Dispatch<React.SetStateAction<"base" | "large" | "small">>;
-};
-export const textSizeContext = createContext<TextSizeContext>({
-  textSize: "large",
-  setTextSize: () => {},
+export type TextSize = "base" | "large" | "small";
+export const textSizeState = atom<TextSize>({
+  key: "textSize",
+  default: "base",
 });

--- a/components/ui/TextSizeSetting/TextSizeSetting.tsx
+++ b/components/ui/TextSizeSetting/TextSizeSetting.tsx
@@ -1,16 +1,17 @@
-import React, { useContext } from "react";
-import { TextSizeContext, textSizeContext } from "../P/textSize";
+import React from "react";
+import { useRecoilState } from "recoil";
+import { TextSize, textSizeState } from "../P/textSize";
 import style from "./TextSizeSetting.module.css";
 type Props = {};
 
-const sizeList: { value: TextSizeContext["textSize"]; label: string }[] = [
+const sizeList: { value: TextSize; label: string }[] = [
   { value: "small", label: "小" },
   { value: "base", label: "中" },
   { value: "large", label: "大" },
 ];
 
 const TextSizeSetting: React.VFC<Props> = ({}) => {
-  const { textSize, setTextSize } = useContext(textSizeContext);
+  const [textSize, setTextSize] = useRecoilState(textSizeState);
 
   return (
     <div className={style.container}>

--- a/database/favorite.ts
+++ b/database/favorite.ts
@@ -1,23 +1,12 @@
-import React, { createContext, useContext } from "react";
+import React from "react";
+import { atom, useRecoilState } from "recoil";
 import { CityType } from "./dataType";
 import { useCities } from "./useCities";
 
-// favorite（お気に入り）の処理をまとめたファイル。
-// 全体で状態の同期をとるため、contextで共有する。
-// _app.tsxに具体的なモデルについて書くの嫌だから、できたらSWRかRecoilとかで書き換えたい。
+// favorite（「いいね」した市町村）の処理をまとめたファイル。
+// ContextからRecoilに書き換えた！！
 
-type FavoriteContext = {
-  favorite: CityType[];
-  setFavorite: React.Dispatch<React.SetStateAction<CityType[]>>;
-};
-
-// contextの本体。_app.tsxでwrapしている。
-export const favoriteContext = createContext<FavoriteContext>({
-  favorite: [],
-  setFavorite: () => {},
-});
-
-// contextの初期化用の値を返す関数。_app.tsxで使う。
+// favoriteの初期化用の値を返す関数。
 export const getInitialFavorite = () => {
   if (typeof window === "undefined") return [];
 
@@ -31,9 +20,15 @@ export const getInitialFavorite = () => {
   return JSON.parse(item) as CityType[];
 };
 
-// favoriteContextの使用をhooksに切り出し。
+// atom。contextのRecoil版みたいなもの？
+const favoriteState = atom({
+  key: "favorite",
+  default: getInitialFavorite(),
+});
+
+// favoriteStateの使用をhooksに切り出し。
 export const useFavorite = () => {
-  const { favorite, setFavorite } = useContext(favoriteContext);
+  const [favorite, setFavorite] = useRecoilState(favoriteState);
   const cities = useCities().data;
 
   return {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,18 +1,11 @@
 import "../globals.css";
 import type { AppProps } from "next/app";
-import { useState } from "react";
-import { CityType } from "../database/dataType";
-import { textSizeContext, TextSizeContext } from "../components/ui/P/textSize";
 import { RecoilRoot } from "recoil";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const [textSize, setTextSize] = useState<TextSizeContext["textSize"]>("base");
-
   return (
     <RecoilRoot>
-      <textSizeContext.Provider value={{ textSize, setTextSize }}>
-        <Component {...pageProps} />
-      </textSizeContext.Provider>
+      <Component {...pageProps} />
     </RecoilRoot>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,20 +1,19 @@
 import "../globals.css";
 import type { AppProps } from "next/app";
-import { favoriteContext, getInitialFavorite } from "../database/favorite";
 import { useState } from "react";
 import { CityType } from "../database/dataType";
 import { textSizeContext, TextSizeContext } from "../components/ui/P/textSize";
+import { RecoilRoot } from "recoil";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const [favorite, setFavorite] = useState<CityType[]>(getInitialFavorite());
   const [textSize, setTextSize] = useState<TextSizeContext["textSize"]>("base");
 
   return (
-    <textSizeContext.Provider value={{ textSize, setTextSize }}>
-      <favoriteContext.Provider value={{ favorite, setFavorite }}>
+    <RecoilRoot>
+      <textSizeContext.Provider value={{ textSize, setTextSize }}>
         <Component {...pageProps} />
-      </favoriteContext.Provider>
-    </textSizeContext.Provider>
+      </textSizeContext.Provider>
+    </RecoilRoot>
   );
 }
 


### PR DESCRIPTION
#13 
favoriteとtextSizeをContextによる共有から、Recoilによる共有に切り替え！
アプリのRootがスッキリして、全体的にコードの量がかなり減った！使い勝手もContextと大きく変わらない！Recoilすごい