### PR TITLE
ページ遷移のアニメーションを実装

### DIFF
--- a/components/page/DetailPage/DetailPage.tsx
+++ b/components/page/DetailPage/DetailPage.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useCities } from "../../../database/useCities";
 import style from "./DetailPage.module.css";
 import { useFavorite } from "../../../database/favorite";
@@ -7,6 +7,7 @@ import TopPageLink from "../../ui/TopPageLink/TopPageLink";
 import P from "../../ui/P/P";
 import FavoriteIcon from "../../ui/FavoriteIcon/FavoriteIcon";
 import CityStatusTable from "../../model/city/CityStatusTable/CityStatusTable";
+import { CityType } from "../../../database/dataType";
 
 type Props = {};
 
@@ -15,10 +16,18 @@ const DetailPage: React.VFC<Props> = ({}) => {
   const cityId = router.query.cityId as string;
 
   const { data, error } = useCities();
-  const city = data?.find((val) => val.id === cityId);
+  const [city, setCity] = useState<CityType>();
 
   const favorite = useFavorite();
-  const isFavorite = favorite.exist(cityId);
+  const [isFavorite, setIsFavorite] = useState<boolean>(false);
+
+  // アンマウント時のアニメーションが行われる際に、アニメーションが完了するよりも先に、routeが変更されて、
+  // cityIdがundefinedになってしまうので、city, isFavoriteがcityIdの変更に依存しないようにする。
+  useEffect(() => {
+    setCity(data?.find((val) => val.id === cityId));
+    setIsFavorite(favorite.exist(cityId));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
   if (error) return <div>error</div>;
   if (!data) return <div>Loading</div>;

--- a/components/page/pageLayout/PageLayout.tsx
+++ b/components/page/pageLayout/PageLayout.tsx
@@ -14,7 +14,7 @@ const PageLayout: React.VFC<Props> = ({ children }) => {
     <div className={style.container}>
       <header className={style.header}>
         <p className={style.header_text}>北陸まち探しサイト</p>
-        <Link href="favorite">
+        <Link href="/favorite">
           <a className={style.good_button_style}>
             いいね一覧
             <br />♡

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,18 @@
 import "../globals.css";
 import type { AppProps } from "next/app";
 import { RecoilRoot } from "recoil";
+import { AnimatePresence } from "framer-motion";
+import PageLayout from "../components/page/pageLayout/PageLayout";
+import { Router } from "next/router";
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps, router }: AppProps) {
   return (
     <RecoilRoot>
-      <Component {...pageProps} />
+      <PageLayout>
+        <AnimatePresence exitBeforeEnter>
+          <Component {...pageProps} key={router.route} />
+        </AnimatePresence>
+      </PageLayout>
     </RecoilRoot>
   );
 }

--- a/pages/detail/[cityId].tsx
+++ b/pages/detail/[cityId].tsx
@@ -1,13 +1,19 @@
+import { AnimatePresence, motion } from "framer-motion";
 import React from "react";
 import DetailPage from "../../components/page/DetailPage/DetailPage";
-import PageLayout from "../../components/page/pageLayout/PageLayout";
+
 type Props = {};
 
 const Index: React.VFC<Props> = ({}) => {
   return (
-    <PageLayout>
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 1 }}
+    >
       <DetailPage />
-    </PageLayout>
+    </motion.div>
   );
 };
 export default Index;

--- a/pages/detail/[cityId].tsx
+++ b/pages/detail/[cityId].tsx
@@ -7,10 +7,10 @@ type Props = {};
 const Index: React.VFC<Props> = ({}) => {
   return (
     <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 1 }}
+      initial={{ opacity: 0, x: -50 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.5 }}
+      exit={{ opacity: 0, x: 50 }}
     >
       <DetailPage />
     </motion.div>

--- a/pages/favorite.tsx
+++ b/pages/favorite.tsx
@@ -1,8 +1,19 @@
+import { motion } from "framer-motion";
 import type { NextPage } from "next";
 import FavoritePage from "../components/page/FavoritePage/FavoritePage";
 
 const Home: NextPage = () => {
-  return <FavoritePage />;
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -50 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.5 }}
+      exit={{ opacity: 0, x: 50 }}
+      style={{ width: "100%" }}
+    >
+      <FavoritePage />
+    </motion.div>
+  );
 };
 
 export default Home;

--- a/pages/favorite.tsx
+++ b/pages/favorite.tsx
@@ -1,13 +1,8 @@
 import type { NextPage } from "next";
 import FavoritePage from "../components/page/FavoritePage/FavoritePage";
-import PageLayout from "../components/page/pageLayout/PageLayout";
 
 const Home: NextPage = () => {
-  return (
-    <PageLayout>
-      <FavoritePage />
-    </PageLayout>
-  );
+  return <FavoritePage />;
 };
 
 export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,19 @@
+import { motion } from "framer-motion";
 import type { NextPage } from "next";
 import TopPage from "../components/page/TopPage/TopPage";
 
 const Home: NextPage = () => {
-  return <TopPage />;
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -50 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.5 }}
+      exit={{ opacity: 0, x: 50 }}
+      style={{ width: "100%" }}
+    >
+      <TopPage />
+    </motion.div>
+  );
 };
 
 export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,8 @@
 import type { NextPage } from "next";
-import PageLayout from "../components/page/pageLayout/PageLayout";
 import TopPage from "../components/page/TopPage/TopPage";
 
 const Home: NextPage = () => {
-  return (
-    <PageLayout>
-      <TopPage />
-    </PageLayout>
-  );
+  return <TopPage />;
 };
 
 export default Home;


### PR DESCRIPTION
motion-framerを使って、各ページへのページングアニメーションを実装。
現時点では、全てのページで「透明度を0~100%, x座標を左から右へ」というアニメーションを設定している。各ページごとに異なるアニメーションを設定出来るので、必要なら更新する。